### PR TITLE
Implements functions for finding files changed since last push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,9 @@ ENV/
 # mypy
 .mypy_cache/
 
+# Profiling
+prof
+
 # IDE settings
 .vscode/
 node_modules

--- a/enguard/config.py
+++ b/enguard/config.py
@@ -26,6 +26,7 @@ data Guard = Guard {
 """
 
 from pathlib import Path
+
 import yaml
 
 CONF_PATH = ".enguard.yml"

--- a/enguard/enguard.py
+++ b/enguard/enguard.py
@@ -4,9 +4,9 @@ import os
 
 from pydriller import GitRepository
 
-from enguard.io import FileIO
 from enguard.config import init_config
 from enguard.hooks import install_hooks
+from enguard.io import FileIO
 
 
 def init(path=os.curdir):

--- a/enguard/experiments.py
+++ b/enguard/experiments.py
@@ -1,17 +1,67 @@
 """Experiment with potential solutions."""
-
-from typing import List
+import re
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import List, Optional
 
 import git
-from pydriller import GitRepository
 
 from enguard.util import repo_path
 
 ASSERTION = True
 
 
-def list_staged_files(repo: GitRepository) -> List[str]:
+class GitChange(Enum):
+    Add = "A"
+    Mod = "M"
+    Del = "D"
+
+
+@dataclass(frozen=True)
+class GitFile:
+    path: Path
+    change_type: Optional[GitChange] = None
+
+    @classmethod
+    def from_diff_line(cls, base: Path, diff_line):
+        change_type, filename = diff_line
+        return GitFile(base / filename, change_type)
+
+    def where_change_type(self, change_type: GitChange):
+        if change_type is self.change_type:
+            return self
+        else:
+            return GitFile(self.path, change_type)
+
+
+def list_staged_files(repo: git.Repo) -> List[str]:
     """List staged files in git."""
-    client = git.cmd.Git(repo.path)
-    filenames = client.diff(name_only=True, staged=True).splitlines()
-    return [repo_path(repo) / filename for filename in filenames]
+    diff = repo.git.diff(name_status=True, staged=True)
+    return git_files_to_path(repo_path(repo), parse_diff(diff))
+
+
+def list_files_since_last_push(repo: git.Repo) -> List[str]:
+    if repo.active_branch.tracking_branch():
+        diff = repo.git.diff("@{push}..HEAD", name_status=True)
+    else:
+        diff = repo.git.diff("master..HEAD", name_status=True)
+    return git_files_to_path(repo_path(repo), parse_diff(diff))
+
+
+def git_files_to_path(base: Path, files):
+    return [GitFile.from_diff_line(base, diff_line) for diff_line in files]
+
+
+def parse_diff(diff):
+    return [parse_diff_line(line) for line in diff.splitlines()]
+
+
+def parse_diff_line(diff_line: str):
+    match = re.match(r"^(A|M|D)\s+(.*)$", diff_line)
+
+    if match is None:
+        raise ValueError("diff_line does not have form: mode path")
+
+    change_type, filename = match.groups()
+    return GitChange(change_type), filename

--- a/enguard/util.py
+++ b/enguard/util.py
@@ -1,22 +1,13 @@
 """Useful utility functions."""
 
-import tempfile
 from pathlib import Path
 
 from git import Repo
-from pydriller import GitRepository
 
 
-def init_temp_repo() -> GitRepository:
-    """Init a temporary git repo."""
-    dir = tempfile.mkdtemp()
-    Repo.init(dir)
-    return GitRepository(dir)
-
-
-def repo_path(repo: GitRepository) -> Path:
+def repo_path(repo: Repo) -> Path:
     """Convert a path relative to the repo and returns an absolute path."""
-    return Path(repo.path)
+    return Path(repo.working_dir)
 
 
 def identity(x):

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ more-itertools==8.3.0
 Faker==4.1.0
 pytest-profiling==1.7.0
 snakeviz==2.1.0
+dataclasses==0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,6 @@ yamllint==1.23.0
 isort==4.3.21
 hypothesis==5.15.1
 more-itertools==8.3.0
+Faker==4.1.0
+pytest-profiling==1.7.0
+snakeviz==2.1.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """Shared test fixtures."""
 import pytest
 
-from enguard.util import init_temp_repo
+from tests.util import init_temp_repo
 
 
 @pytest.fixture

--- a/tests/drivers.py
+++ b/tests/drivers.py
@@ -1,0 +1,69 @@
+import tempfile
+from pathlib import Path
+
+from git import Repo
+
+from enguard.experiments import GitChange, GitFile
+
+
+class GitPush:
+    pass
+
+
+class GitDriver:
+    @classmethod
+    def pushable_clone(cls):
+        bare_repo_dir = tempfile.mkdtemp()
+        bare_repo = Repo.init(bare_repo_dir, bare=True)
+        assert bare_repo.bare
+
+        repo_dir = tempfile.mkdtemp()
+        return cls.from_repo(bare_repo.clone(repo_dir))
+
+    @classmethod
+    def from_repo(cls, repo: Repo):
+        return cls(repo)
+
+    def __init__(self, repo: Repo):
+        self.repo = repo
+        self.index = repo.index
+
+    def commit(self):
+        return
+
+    def _tmp_file(self):
+        with tempfile.NamedTemporaryFile(
+            dir=self.repo.working_dir, delete=False, mode="w"
+        ) as staged:
+            staged.write("This is some random content")
+            return staged.name
+
+    def stage(self):
+        filename = self._tmp_file()
+        self.index.add([filename])
+        return GitFile(self.path / filename)
+
+    def add(self, commitmsg):
+        file = self.stage()
+        self.index.commit(commitmsg)
+        return file
+
+    def push(self):
+        self.repo.remote().push()
+
+    def modify(self, file: GitFile):
+        with open(file.path, "w") as f:
+            f.write("This is some new data")
+        self.index.add([str(file.path)])
+
+    def branch(self, branch="test/branch"):
+        branch = self.repo.create_head("test/branch", "HEAD")
+        self.repo.head.reference = branch
+
+    @property
+    def is_pristine(self):
+        return not self.repo.git.status(porcelain=True)
+
+    @property
+    def path(self):
+        return Path(self.repo.working_dir)

--- a/tests/e2e/test_init.py
+++ b/tests/e2e/test_init.py
@@ -2,6 +2,8 @@
 
 """Tests for `enguard init` command."""
 
+import os
+
 import pytest
 import yaml
 from click.testing import CliRunner
@@ -12,7 +14,6 @@ from enguard.config import DEFAULT_CONF, config_path
 from enguard.hooks import hooks_path
 from enguard.util import repo_path
 from tests.util import hooks_ok
-import os
 
 
 @pytest.mark.acceptance

--- a/tests/e2e/test_run_hook.py
+++ b/tests/e2e/test_run_hook.py
@@ -2,8 +2,9 @@
 
 import pytest
 from click.testing import CliRunner
-from tests.util import exit_ok
+
 from enguard.cli import run_hook
+from tests.util import exit_ok
 
 
 @pytest.mark.acceptance

--- a/tests/experiments/test_experiments.py
+++ b/tests/experiments/test_experiments.py
@@ -1,21 +1,127 @@
 """Test output of experiments for features under development."""
 
 import pytest
-from pydriller import GitRepository
+from git.repo.base import Repo
 
-from enguard.experiments import list_staged_files
+from enguard.experiments import (list_files_since_last_push, list_staged_files,
+                                 parse_diff_line,)
 from enguard.util import repo_path
+from tests.drivers import GitChange, GitDriver
 from tests.util import stage_tmp_file
 
 
 @pytest.mark.experiments
-def test_list_staged_files(repo: GitRepository):
+def test_list_staged_files(repo: Repo):
     """Test list_staged_files returns only staged files."""
-    filename = stage_tmp_file(repo)
-    assert repo_path(repo) / filename in list_staged_files(repo)
+    driver = GitDriver.from_repo(repo)
+    file = driver.stage()
+    assert file.where_change_type(GitChange.Add) in list_staged_files(repo)
 
 
 @pytest.mark.experiments
-def test_list_staged_files_is_empty(repo: GitRepository):
+def test_list_staged_files_is_empty(repo: Repo):
     """Test list_staged_Files returns empty list if nothing staged."""
     assert not list_staged_files(repo)
+
+
+@pytest.mark.experiments
+def test_git_file(repo: Repo):
+    pass
+
+
+@pytest.mark.experiments
+def test_list_files_changed_since_last_push():
+    driver = GitDriver.pushable_clone()
+
+    temp1 = driver.add("This is a test commit")
+    driver.push()
+
+    temp2 = driver.add("This is a test commit 2")
+    temp3 = driver.add("This is a test commit 3")
+
+    driver.modify(temp1)
+    driver.modify(temp2)
+    temp4 = driver.add("This is a test commit 4")
+
+    diff = list_files_since_last_push(driver.repo)
+    print(diff[0])
+    assert temp1.where_change_type(GitChange.Mod) in diff
+    assert temp2.where_change_type(GitChange.Add) in diff
+    assert temp3.where_change_type(GitChange.Add) in diff
+    assert temp4.where_change_type(GitChange.Add) in diff
+
+    assert driver.is_pristine
+
+
+@pytest.mark.experiments
+def test_list_files_changed_since_last_push_branch_from_master():
+    driver = GitDriver.pushable_clone()
+
+    temp1 = driver.add("This is a test commit")
+    driver.push()
+
+    driver.branch()
+
+    temp2 = driver.add("This is a test commit 2")
+    temp3 = driver.add("This is a test commit 3")
+
+    driver.modify(temp1)
+    driver.modify(temp2)
+    temp4 = driver.add("This is a test commit 4")
+
+    diff = list_files_since_last_push(driver.repo)
+    assert temp1.where_change_type(GitChange.Mod) in diff
+    assert temp2.where_change_type(GitChange.Add) in diff
+    assert temp3.where_change_type(GitChange.Add) in diff
+    assert temp4.where_change_type(GitChange.Add) in diff
+
+    assert driver.is_pristine
+
+
+@pytest.mark.experiments
+def test_list_files_changed_since_last_push_without_origin(repo):
+    driver = GitDriver.from_repo(repo)
+
+    temp1 = driver.add("This is a test commit 1")
+
+    driver.branch()
+
+    temp2 = driver.add("This is a test commit 2")
+    temp3 = driver.add("This is a test commit 3")
+
+    driver.modify(temp1)
+    driver.modify(temp2)
+    temp4 = driver.add("This is a test commit 4")
+
+    diff = list_files_since_last_push(driver.repo)
+    assert temp1.where_change_type(GitChange.Mod) in diff
+    assert temp2.where_change_type(GitChange.Add) in diff
+    assert temp3.where_change_type(GitChange.Add) in diff
+    assert temp4.where_change_type(GitChange.Add) in diff
+
+    assert driver.is_pristine
+
+
+@pytest.mark.experiments
+def test_parse_diff_line():
+    assert parse_diff_line("A\tfilename.txt") == (GitChange("A"), "filename.txt")
+    assert parse_diff_line("M\tfile-slug.txt") == (GitChange("M"), "file-slug.txt")
+
+
+@pytest.mark.experiments
+def test_list_files_inbound_from_merge(repo: Repo):
+    # TODO: How do we simulate a merge?
+    driver = GitDriver.from_repo(repo)
+
+    temp1 = driver.add("This is a test commit 1")
+
+    driver.branch()
+
+    temp2 = driver.add("This is a test commit 2")
+    temp3 = driver.add("This is a test commit 3")
+
+    driver.modify(temp1)
+    driver.modify(temp2)
+    temp4 = driver.add("This is a test commit 4")
+
+    assert driver.is_pristine

--- a/tests/experiments/test_githooks.py
+++ b/tests/experiments/test_githooks.py
@@ -21,12 +21,13 @@ def test_register_git_hooks(repo: Repo):
 
     stage_tmp_file(repo)
 
+    # Not using capture_output due to 3.6 support
     result = subprocess.run(
         ["git", "commit", "-m", "test"],
         check=True,
-        capture_output=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
         cwd=repo_path(repo),
-        text=True,
     )
 
     assert result.returncode == 0

--- a/tests/experiments/test_githooks.py
+++ b/tests/experiments/test_githooks.py
@@ -1,19 +1,20 @@
+import os
 import subprocess
-import pytest
 
-from pydriller import GitRepository
+import pytest
+from git import Repo
 
 from enguard.hooks import HOOKS, hooks_path, install_hook
-from tests.util import hooks_ok, stage_tmp_file, exit_ok
-import os
+from enguard.util import repo_path
+from tests.util import hooks_ok, stage_tmp_file
 
 
 @pytest.mark.experiments
-def test_register_git_hooks(repo: GitRepository):
-    path = hooks_path(repo.path)
+def test_register_git_hooks(repo: Repo):
+    path = hooks_path(repo_path(repo))
 
     for hook in HOOKS:
-        install_hook(hook, repo.path)
+        install_hook(hook, repo_path(repo))
 
     with os.scandir(path) as entries:
         assert hooks_ok(entries)
@@ -24,8 +25,8 @@ def test_register_git_hooks(repo: GitRepository):
         ["git", "commit", "-m", "test"],
         check=True,
         capture_output=True,
-        cwd=repo.path,
+        cwd=repo_path(repo),
         text=True,
     )
 
-    assert exit_ok(result.returncode)
+    assert result.returncode == 0

--- a/tests/integration/test_hook_io.py
+++ b/tests/integration/test_hook_io.py
@@ -1,13 +1,14 @@
 import pytest
+from git import Repo
 
-from pydriller import GitRepository
 from enguard.hooks import Hook
 from enguard.io import FileIO
+from enguard.util import repo_path
 
 
 @pytest.mark.integration
-def test_integrate_hook_with_io(repo: GitRepository):
-    hook = Hook("test-hook", repo.path)
+def test_integrate_hook_with_io(repo: Repo):
+    hook = Hook("test-hook", repo_path(repo))
 
     io = FileIO()
     assert not io.exists(hook.path)

--- a/tests/unit/test_hook.py
+++ b/tests/unit/test_hook.py
@@ -1,6 +1,7 @@
+from pathlib import Path
+
 import pytest
 
-from pathlib import Path
 from enguard.hooks import Hook, hook_script, install_hooks
 from enguard.io import MemIO
 

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,23 +1,23 @@
 """Tests project utility functions."""
 
 import os
-
-import pytest
-
-from enguard.util import init_temp_repo
-from hypothesis import given
-import hypothesis.strategies as st
-from operator import add, mul
 from functools import partial
+from operator import add, mul
+
+import hypothesis.strategies as st
+import pytest
+from hypothesis import given
+
 from enguard.util import complement, compose, const
+from tests.util import init_temp_repo
 
 
 @pytest.mark.unit
 def test_init_temp_repo_can_be_closed():
     """Test that init_temp_repo cleans up."""
     repo = init_temp_repo()
-    assert os.path.isdir(repo.path)
-    repo.repo.close()
+    assert os.path.isdir(repo.working_dir)
+    repo.close()
 
 
 @given(st.integers(), st.integers(), st.integers())

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,7 +1,8 @@
-import os
+import tempfile
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 
-from pydriller import GitRepository
+from git import Repo
 
 from enguard.hooks import hooks_exist
 from enguard.util import entry_names
@@ -9,14 +10,25 @@ from enguard.util import entry_names
 # TODO: Reconsider naming of these e.g for_all_files_in
 
 
+def init_temp_repo() -> Repo:
+    """Init a temporary git repo."""
+    dir = tempfile.mkdtemp()
+    return Repo.init(dir)
+
+
 def hooks_ok(entries):
     return hooks_exist(entry_names(entries))
 
 
-def stage_tmp_file(repo: GitRepository):
-    with NamedTemporaryFile(dir=repo.path, delete=False) as staged:
-        repo.repo.index.add([staged.name])
-        return staged.name
+def stage_tmp_file(repo: Repo, prefix=None):
+    filename = ""
+    with NamedTemporaryFile(
+        dir=repo.working_dir, delete=False, prefix=prefix, mode="w"
+    ) as staged:
+        staged.write("This is some random content")
+        filename = staged.name
+    repo.index.add([filename])
+    return filename
 
 
 def exit_ok(exit_code):


### PR DESCRIPTION
I have established a method to retrieve outgoing changes. To do this, I have refactored the test cases to use a GitDriver, which hides git's commands.

Closes #14

**Changes:**

refactor: refactor out use of pydriller

experiment: add cases for push diffs and refactor

This commit:

- Implements more test cases for files to push
- Implements the start of listing files from merge experiment
- Refactors the test code into a driver
- Introduce a GitChange type

chore: remove unused imports and functions

build: install profiling tools

refactor: lift git file object to the library